### PR TITLE
CMakeLists: CMAKE_CXX_STANDARD to fix compilation error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 
+#  Without C++11, compile error
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # cmake config
 project(DataTable VERSION 1.0.0 DESCRIPTION "Data Tables for C++")
 include(GNUInstallDirs)


### PR DESCRIPTION
Without this fix, I am getting
`msenel@MACC02CJ3J6LVDL build % make
Scanning dependencies of target DataTable
[ 33%] Building CXX object CMakeFiles/DataTable.dir/src/DataTable/DataTable.cc.o
warning: unknown warning option '-Wno-psabi' [-Wunknown-warning-option]
In file included from /Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:1:
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:81:35: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            std::string* _headers = 0;
                                  ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:82:28: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            double** _data = 0;
                           ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:83:23: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            int _cols = 0;
                      ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:84:23: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            int _rows = 0;
                      ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:85:35: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            std::string _response = "";
                                  ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:86:34: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            int _response_column = 0;
                                 ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:87:31: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            bool _data_loaded = false;
                              ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:88:31: warning: in-class initialization of non-static data member is a C++11
      extension [-Wc++11-extensions]
            bool _has_headers = false;
                              ^
/Users/msenel/Documents/workspace/DataTables2/include/DataTable/DataTable.hpp:78:45: error: expected ';' after return statement
            int* shape() { return new int[2] { _rows, _cols }; }
                                            ^
                                            ;
/Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:185:13: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
        for(auto it = lines.begin(); it != lines.end(); it++)
            ^
/Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:562:32: error: expected ')'
        drop_columns(new int[1]{column}, 1);
                               ^
/Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:562:21: note: to match this '('
        drop_columns(new int[1]{column}, 1);
                    ^
/Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:567:40: error: expected ')'
        drop_columns(new std::string[1]{column}, 1);
                                       ^
/Users/msenel/Documents/workspace/DataTables2/src/DataTable/DataTable.cc:567:21: note: to match this '('
        drop_columns(new std::string[1]{column}, 1);
                    ^
10 warnings and 3 errors generated.
make[2]: *** [CMakeFiles/DataTable.dir/src/DataTable/DataTable.cc.o] Error 1
make[1]: *** [CMakeFiles/DataTable.dir/all] Error 2
make: *** [all] Error 2`
